### PR TITLE
upgrade tokio-tls and native-tls to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ uuid = { version = "0.5", features = ["v4"] }
 futures = { version = "0.1", optional = true }
 tokio-core = { version = "0.1", optional = true }
 tokio-io = { version = "^0.1.2", optional = true }
-tokio-tls = { version = "0.1", optional = true }
+tokio-tls = { version = "0.2.0", optional = true }
 bytes = { version = "0.4", optional = true }
-native-tls = { version = "^0.1.2", optional = true }
+native-tls = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 futures-cpupool = "0.1"

--- a/src/result.rs
+++ b/src/result.rs
@@ -140,7 +140,7 @@ impl<T> From<TlsHandshakeError<T>> for WebSocketError {
 	fn from(err: TlsHandshakeError<T>) -> WebSocketError {
 		match err {
 			TlsHandshakeError::Failure(_) => WebSocketError::TlsHandshakeFailure,
-			TlsHandshakeError::Interrupted(_) => WebSocketError::TlsHandshakeInterruption,
+			TlsHandshakeError::WouldBlock(_) => WebSocketError::TlsHandshakeInterruption,
 		}
 	}
 }

--- a/src/server/async.rs
+++ b/src/server/async.rs
@@ -13,7 +13,7 @@ pub use tokio_core::reactor::Handle;
 #[cfg(any(feature="async-ssl"))]
 use native_tls::TlsAcceptor;
 #[cfg(any(feature="async-ssl"))]
-use tokio_tls::{TlsAcceptorExt, TlsStream};
+use tokio_tls::TlsStream;
 
 /// The asynchronous specialization of a websocket server.
 /// Use this struct to create asynchronous servers.
@@ -110,6 +110,8 @@ impl WsServer<TlsAcceptor, TcpListener> {
 	/// example for a good echo server example.
 	pub fn incoming(self) -> Incoming<TlsStream<TcpStream>> {
 		let acceptor = self.ssl_acceptor;
+		let acceptor = tokio_tls::TlsAcceptor::from(acceptor);
+
 		let future = self.listener
 		                 .incoming()
 		                 .map_err(|e| {
@@ -121,7 +123,7 @@ impl WsServer<TlsAcceptor, TcpListener> {
 			                          }
 			                         })
 		                 .and_then(move |(stream, a)| {
-			acceptor.accept_async(stream)
+			acceptor.accept(stream)
 			        .map_err(|e| {
 				InvalidConnection {
 					stream: None,


### PR DESCRIPTION
I'm running into problems using serenity because my system's version of openssl is too new (see sfackler/rust-openssl#987 for a similar problem). This PR upgrades tokio-tls and native-tls (and transitively rust-openssl) to fix this issue.

The changes are just to migrate to the new `tokio_tls::{TlsAcceptor, TlsConnector}` types and to use them where appropriate (only in a few async functions). The crate builds and the unit tests pass.